### PR TITLE
NACA trailing edge fix

### DIFF
--- a/prefoil/utils/geom_ops.py
+++ b/prefoil/utils/geom_ops.py
@@ -21,7 +21,8 @@ def generateNACA(code, nPts, spacingFunc=sampling.cosine, func_args=None):
     code : str
         The 4 digit code, this is expected to be a length four string
     nPts : int
-        The number of points to sample from the defintion of the NACA airfoil, half will be sampled on the top and half on the bottom
+        The number of points to sample from the defintion of the NACA airfoil, half will be sampled on the top and half on the bottom.
+        This must be an even number.
     spacingFunc : callable
         The spacing function to use for determining the sampling point locations of the x coordinates of the camber line
     func_args : dict
@@ -41,6 +42,9 @@ def generateNACA(code, nPts, spacingFunc=sampling.cosine, func_args=None):
 
     if not func_args:
         func_args = {}
+
+    if nPts % 2 != 0:
+        raise ValueError("nPts must be an even number.")
 
     camber_x = spacingFunc(0.0, 1.0, nPts // 2, **func_args)
     camber_y = np.zeros_like(camber_x)

--- a/prefoil/utils/geom_ops.py
+++ b/prefoil/utils/geom_ops.py
@@ -60,40 +60,28 @@ def generateNACA(code, nPts, spacingFunc=sampling.cosine, func_args=None):
             camber_y[i] = m / (1 - p) ** 2 * ((1 - 2 * p) + 2 * p * camber_x[i] - camber_x[i] ** 2)
 
     for i in range(len(camber_x)):
-        # edge cases
-        if i == 0:
-            upper_x[i] = 0
-            lower_x[i] = 0
-            upper_y[i] = 0
-            lower_y[i] = 0
-        elif i == len(camber_x) - 1:
-            upper_x[i] = 1
-            lower_x[i] = 1
-            upper_y[i] = 0
-            lower_y[i] = 0
-        else:
-            thick_y = (
-                t
-                / 0.2
-                * (
-                    0.2969 * np.sqrt(camber_x[i])
-                    - 0.126 * camber_x[i]
-                    - 0.3516 * camber_x[i] ** 2
-                    + 0.2843 * camber_x[i] ** 3
-                    - 0.1015 * camber_x[i] ** 4
-                )
+        thick_y = (
+            t
+            / 0.2
+            * (
+                0.2969 * np.sqrt(camber_x[i])
+                - 0.126 * camber_x[i]
+                - 0.3516 * camber_x[i] ** 2
+                + 0.2843 * camber_x[i] ** 3
+                - 0.1015 * camber_x[i] ** 4
             )
-            if camber_x[i] < p:
-                theta = np.arctan(m / p**2 * (2 * p - 2 * camber_x[i]))
-            else:
-                theta = np.arctan(m / (1 - p) ** 2 * (2 * p - 2 * camber_x[i]))
-            upper_x[i] = camber_x[i] - thick_y * np.sin(theta)
-            lower_x[i] = camber_x[i] + thick_y * np.sin(theta)
-            upper_y[i] = camber_y[i] + thick_y * np.cos(theta)
-            lower_y[i] = camber_y[i] - thick_y * np.cos(theta)
+        )
+        if camber_x[i] < p:
+            theta = np.arctan(m / p**2 * (2 * p - 2 * camber_x[i]))
+        else:
+            theta = np.arctan(m / (1 - p) ** 2 * (2 * p - 2 * camber_x[i]))
+        upper_x[i] = camber_x[i] - thick_y * np.sin(theta)
+        lower_x[i] = camber_x[i] + thick_y * np.sin(theta)
+        upper_y[i] = camber_y[i] + thick_y * np.cos(theta)
+        lower_y[i] = camber_y[i] - thick_y * np.cos(theta)
 
     coords = np.hstack(
-        (np.concatenate((np.flip(upper_x)[1:], lower_x[1:-1])), np.concatenate((np.flip(upper_y)[1:], lower_y[1:-1])))
+        (np.concatenate((np.flip(upper_x[1:]), lower_x)), np.concatenate((np.flip(upper_y[1:]), lower_y)))
     )
 
     return coords

--- a/tests/test_prefoil.py
+++ b/tests/test_prefoil.py
@@ -123,14 +123,15 @@ class TestBasic(unittest.TestCase):
         af = Airfoil(generateNACA("0012", 200))
         self.assertFalse(af.closedCurve)
         assert_allclose(np.array([0.0, 0.0]), af.LE, atol=1e-12)
-        assert_allclose(np.array([1.0, 0.0]), af.TE, atol=3e-3)
+        assert_allclose(np.array([1.0, 0.0]), af.TE, atol=1e-12)
+        assert_allclose(0.00126 * 2, af.getTEThickness(), atol=1e-12)
         self.assertTrue(af.isSymmetric())
         assert_allclose((0.30, 0.12), af.getMaxThickness("american"), atol=1e-4)
 
     def test_generateNACA_6412(self):
         af = Airfoil(generateNACA("6412", 1000))
         self.assertFalse(af.closedCurve)
-        assert_allclose(np.array([1.0, 0.0]), af.TE, atol=1e-4)
+        assert_allclose(np.array([1.0, 0.0]), af.TE, atol=1e-12)
         self.assertFalse(af.isSymmetric())
         assert_allclose((0.30, 0.12), af.getMaxThickness("american"), atol=1e-4)
         assert_allclose((0.396, 0.06), af.getMaxCamber(), atol=3e-2)


### PR DESCRIPTION
## Purpose
<!--
Explain the goal of this PR, if it addresses an existing issue be sure to link to it.
Describe the big picture of your changes here, perhaps using a bullet list if multiple changes are done to accomplish a single goal.
If this PR accomplishes multiple goals, it may be best to create separate PR's for each.
-->
I fixed a bug in `generateNACA` where the trailing edge points were being discarded. Now the airfoils end at exactly unit chord and have the correct trailing edge thickness. In addition, the number of points around the airfoil is now nPts - 1 instead of nPts - 3.

The black line in this figure is the main branch and the blue line is with my fix:
![prefoil_te_fix](https://github.com/mdolab/prefoil/assets/48863473/35011ff4-8a4e-48e0-abb2-be57f102cbdf)

This bug was apparent from the trailing edge tests because the tolerances were very loose. I tightened the tolerances. I also added a trailing edge thickness test for the NACA 0012.

## Expected time until merged
<!--
Comment on whether or not this change is urgent and how long you expect this PR to take to review and be merged.
For example, a week would be a reasonable time frame for an average, non-urgent PR.
-->
1 week

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [x] I have run unit and regression tests which pass locally with my changes
- [x] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
